### PR TITLE
Debugging gmg neumann

### DIFF
--- a/src/GMG/InterGridTransferOperators.jl
+++ b/src/GMG/InterGridTransferOperators.jl
@@ -267,7 +267,15 @@ function LinearAlgebra.mul!(x::PVector,
     uH = nothing
   end
 
+  # iter=rand(1:1000)
+  # map_parts(uH.fields) do uH
+  #   writevtk(get_triangulation(uH),"uH_$(iter)",cellfields=["uH" => uH])
+  # end
+
   uH_h = change_domain_coarse_to_fine(uH,A.Ωh_ghost,A.mesh_hierarchy_level.ref_glue)
+  # map_parts(uH_h.fields) do uH_h
+  #   writevtk(get_triangulation(uH_h),"uH_h_$(iter)",cellfields=["uH_h" => uH_h])
+  # end
 
   l(v) = ∫(v⋅uH_h)A.dΩh
   Gridap.FESpaces.assemble_vector!(l,A.dof_values_h_sys_layout_b,A.Vh)
@@ -300,6 +308,14 @@ function LinearAlgebra.mul!(x::PVector,
                          A.dof_values_h_sys_layout_b;
                          verbose=(i_am_main(parts) && verbose),
                          reltol=reltol)
+
+    uh = FEFunction(A.Uh,
+                    x,
+                    map_parts(A.Uh.spaces) do space
+                      zeros(num_dirichlet_dofs(space))
+                    end)
+
+    # writevtk(A.Ωh,"uh_$(iter)", cellfields=["uh" => uh])
   end
 end
 
@@ -403,6 +419,11 @@ function LinearAlgebra.mul!(x::Union{PVector,Nothing},
     uh = FEFunction(A.Uh,
                     A.dof_values_h_fe_space_layout_red,
                     A.uh_zero_dirichlet_values_red)
+    iter=readchomp(`date +%s`)
+    sleep(1.0)
+    map_parts(uh.fields) do uh
+        writevtk(get_triangulation(uh),"rh_$(iter)",cellfields=["rh" => uh])
+    end
   end
 
   # uh is in h communicator, but with void parts for those tasks not in the next level
@@ -423,6 +444,11 @@ function LinearAlgebra.mul!(x::Union{PVector,Nothing},
     uH = FEFunction(A.UH,
                     x,
                     A.uH_zero_dirichlet_values)
+
+
+    map_parts(uH.fields) do uH
+        writevtk(get_triangulation(uH),"rH_$(iter)",cellfields=["rH" => uH])
+    end
   end
 end
 

--- a/src/GMG/InterGridTransferOperators.jl
+++ b/src/GMG/InterGridTransferOperators.jl
@@ -308,14 +308,6 @@ function LinearAlgebra.mul!(x::PVector,
                          A.dof_values_h_sys_layout_b;
                          verbose=(i_am_main(parts) && verbose),
                          reltol=reltol)
-
-    uh = FEFunction(A.Uh,
-                    x,
-                    map_parts(A.Uh.spaces) do space
-                      zeros(num_dirichlet_dofs(space))
-                    end)
-
-    # writevtk(A.Ωh,"uh_$(iter)", cellfields=["uh" => uh])
   end
 end
 

--- a/src/GMG/InterGridTransferOperators.jl
+++ b/src/GMG/InterGridTransferOperators.jl
@@ -419,11 +419,6 @@ function LinearAlgebra.mul!(x::Union{PVector,Nothing},
     uh = FEFunction(A.Uh,
                     A.dof_values_h_fe_space_layout_red,
                     A.uh_zero_dirichlet_values_red)
-    iter=readchomp(`date +%s`)
-    sleep(1.0)
-    map_parts(uh.fields) do uh
-        writevtk(get_triangulation(uh),"rh_$(iter)",cellfields=["rh" => uh])
-    end
   end
 
   # uh is in h communicator, but with void parts for those tasks not in the next level
@@ -441,14 +436,6 @@ function LinearAlgebra.mul!(x::Union{PVector,Nothing},
                          A.dof_values_H_sys_layout_b;
                          reltol=reltol,
                          verbose=(i_am_main(parts) && verbose))
-    uH = FEFunction(A.UH,
-                    x,
-                    A.uH_zero_dirichlet_values)
-
-
-    map_parts(uH.fields) do uH
-        writevtk(get_triangulation(uH),"rH_$(iter)",cellfields=["rH" => uH])
-    end
   end
 end
 

--- a/src/GMG/InterGridTransferOperators.jl
+++ b/src/GMG/InterGridTransferOperators.jl
@@ -267,15 +267,7 @@ function LinearAlgebra.mul!(x::PVector,
     uH = nothing
   end
 
-  # iter=rand(1:1000)
-  # map_parts(uH.fields) do uH
-  #   writevtk(get_triangulation(uH),"uH_$(iter)",cellfields=["uH" => uH])
-  # end
-
   uH_h = change_domain_coarse_to_fine(uH,A.Ωh_ghost,A.mesh_hierarchy_level.ref_glue)
-  # map_parts(uH_h.fields) do uH_h
-  #   writevtk(get_triangulation(uH_h),"uH_h_$(iter)",cellfields=["uH_h" => uH_h])
-  # end
 
   l(v) = ∫(v⋅uH_h)A.dΩh
   Gridap.FESpaces.assemble_vector!(l,A.dof_values_h_sys_layout_b,A.Vh)

--- a/test/GMG/mpi/GMGLinearSolversHDivRTTests.jl
+++ b/test/GMG/mpi/GMGLinearSolversHDivRTTests.jl
@@ -1,4 +1,4 @@
-module GMGLinearSolverHDivRTTests
+#module GMGLinearSolverHDivRTTests
   using MPI
   using Gridap
   using Gridap.FESpaces
@@ -78,12 +78,12 @@ module GMGLinearSolverHDivRTTests
     domain=(0,1,0,1)
 
     reffe=ReferenceFE(raviart_thomas,Float64,order)
-    qdegree=2*(order+1)
+    qdegree=10*(order+1)
 
     cmodel=CartesianDiscreteModel(domain,coarse_grid_partition)
     mh=ModelHierarchy(parts,cmodel,num_parts_x_level)
 
-    tests    = TestFESpace(mh,reffe; dirichlet_tags="boundary")
+    tests    = TestFESpace(mh,reffe; dirichlet_tags=[7,8])
     trials   = TrialFESpace(u,tests)
     fespaces = (tests,trials)
     smatrices= generate_stiffness_matrices(mh,fespaces,qdegree,α)
@@ -145,10 +145,10 @@ module GMGLinearSolverHDivRTTests
   parts = get_part_ids(mpi,1)
   order=0
 
-  num_refinements=[1,2,3,4,5]
-  alpha_exps=[0,1,2,3,4]
+  num_refinements=[1]#,2,3,4,5]
+  alpha_exps=[0]#,1,2,3,4]
   iter_matrix=zeros(Int,5,5)
-  coarse_grid_partition=(1,1)
+  coarse_grid_partition=(30,30)
   free_dofs=Vector{Int64}(undef,length(num_refinements))
 
   for ref=1:length(num_refinements)
@@ -164,4 +164,4 @@ module GMGLinearSolverHDivRTTests
   println(free_dofs)
 
   MPI.Finalize()
-end
+# end

--- a/test/GMG/mpi/GMGLinearSolversHDivRTTests.jl
+++ b/test/GMG/mpi/GMGLinearSolversHDivRTTests.jl
@@ -78,12 +78,12 @@
     domain=(0,1,0,1)
 
     reffe=ReferenceFE(raviart_thomas,Float64,order)
-    qdegree=10*(order+1)
+    qdegree=2*(order+1)
 
     cmodel=CartesianDiscreteModel(domain,coarse_grid_partition)
     mh=ModelHierarchy(parts,cmodel,num_parts_x_level)
 
-    tests    = TestFESpace(mh,reffe; dirichlet_tags=[7,8])
+    tests    = TestFESpace(mh,reffe)
     trials   = TrialFESpace(u,tests)
     fespaces = (tests,trials)
     smatrices= generate_stiffness_matrices(mh,fespaces,qdegree,α)
@@ -145,10 +145,10 @@
   parts = get_part_ids(mpi,1)
   order=0
 
-  num_refinements=[1]#,2,3,4,5]
-  alpha_exps=[0]#,1,2,3,4]
+  num_refinements=[1,2,3,4,5]
+  alpha_exps=[0,1,2,3,4]
   iter_matrix=zeros(Int,5,5)
-  coarse_grid_partition=(30,30)
+  coarse_grid_partition=(5,5)
   free_dofs=Vector{Int64}(undef,length(num_refinements))
 
   for ref=1:length(num_refinements)

--- a/test/GMG/mpi/GMGLinearSolversHDivRTTests.jl
+++ b/test/GMG/mpi/GMGLinearSolversHDivRTTests.jl
@@ -1,4 +1,4 @@
-#module GMGLinearSolverHDivRTTests
+module GMGLinearSolverHDivRTTests
   using MPI
   using Gridap
   using Gridap.FESpaces
@@ -164,4 +164,4 @@
   println(free_dofs)
 
   MPI.Finalize()
-# end
+end

--- a/test/GMG/seq/PatchLinearSolverTests.jl
+++ b/test/GMG/seq/PatchLinearSolverTests.jl
@@ -12,7 +12,7 @@ module PatchLinearSolverTests
 
     function returns_PD_Ph_xh_Vh(model)
       reffe = ReferenceFE(lagrangian,Float64,order)
-      Vh    = TestFESpace(model,reffe;conformity=:H1)
+      Vh    = TestFESpace(model,reffe)
       PD=PatchDecomposition(model)
       Ph=PatchFESpace(model,reffe,H1Conformity(),PD,Vh)
       assembler=SparseMatrixAssembler(Ph,Ph)
@@ -33,8 +33,8 @@ module PatchLinearSolverTests
     _,dPh,dxh,dVh=returns_PD_Ph_xh_Vh(dmodel);
     _,Ph,xh,Vh=returns_PD_Ph_xh_Vh(model)
     @test num_free_dofs(Ph) == num_free_dofs(dPh)
-    @test all(dxh.owned_values.parts[1] .≈ xh[1:5])
-    @test all(dxh.owned_values.parts[2] .≈ xh[6:end])
+    @test all(dxh.owned_values.parts[1] .≈ xh[1:3])
+    @test all(dxh.owned_values.parts[2] .≈ xh[4:end])
 
     function compute_matrix_vector(model,Vh)
       Ω = Triangulation(model)


### PR DESCRIPTION
This PR fixes issues with `PatchBased` smoothers for problems with Neumann boundary conditions. 

Essentially, those facets in a patch which belong to the global domain boundary and which are not in touch with the vertex at which the patch is centered should be considered patch boundary facets. On the other hand, facets in a patch which belong to the global domain boundary and which are in touch with the patch vertex are excluded from the patch boundary. 

After fixing the results are as follows for 

(I - alpha grad div) u = f

with

* RT (lowest order)
* patch-based linear solver + Richardson iteration (a single iteration, damping factor 1/3; achieves much better results than 1)
* CG + 1-iteration V-cycle as preconditioner.
* alpha varying from 10^0 to 10^5.
* Initial (coarsest) mesh 5x5 quads, 1, 2, 3, ..., 5 uniform refinements.
* Unit square domain, Neumann boundary conditions div u = 0 on the whole boundary 

```
julia> iter_matrix
5×5 Matrix{Int64}:
 14  16  16  16  16
 20  21  21  21  21
 20  21  21  21  21
 26  30  30  30  30
 19  20  20  20  20

julia> free_dofs
5-element Vector{Int64}:
   220
   840
  3280
 12960
 51520
```

The lowest matrix is the number of iterations that take the CG solver to achieve a 10^6 factor reduction in the relative residual. The row identifiers in the matrix denote number of uniform refinements, and the columns the value of alpha.





