### PR TITLE
Set of changes to try to fix pending issues PR #27

### DIFF
--- a/src/Environment.jl
+++ b/src/Environment.jl
@@ -1,6 +1,3 @@
-
-const _NREFS = Ref(0)
-
 """
 See P4est_wrapper.jl/src/bindings/sc_common.jl for possible/valid
 argument values for the p4est_verbosity_level parameter
@@ -9,23 +6,27 @@ function Init(parts::MPIData;p4est_verbosity_level=P4est_wrapper.SC_LP_DEFAULT)
   if !MPI.Initialized()
     @error "MPI not Initialized!"
   end
-
-  sc_init(parts.comm, Cint(true), Cint(true), C_NULL, p4est_verbosity_level)
+  sc_init(parts.comm, Cint(false), Cint(false), C_NULL, p4est_verbosity_level)
   p4est_init(C_NULL, p4est_verbosity_level)
-
   return nothing
 end
 
 function Finalize()
-  GC.gc() # Finalize all object out of scope at this point
-  if _NREFS[] != 0
-    @warn "$(_NREFS[]) object(s) still not finalized before calling GridapP4est.Finalize()"
-  end
-  _NREFS[] = 0
-  # This function call is useful, as among others, it also double checks
-  # for memory leaks as a result of improper usage of p4est/sc. If there are leaks, 
-  # then it generates a fatal error.
-  sc_finalize()
+  GC.gc() # Finalize all objects out of scope at this point
+
+  # The function call to sc_finalize() is useful as, among others, it also
+  # double checks for memory leaks as a result of improper usage
+  # of p4est/sc; if there are leaks, then it generates a fatal
+  # error.
+
+  # HOWEVER ... we cannot call it as we have realized there are
+  # scenarios where the call to GC.gc() above does not necessarily
+  # run synchronously, but scheduled in a co-routine/task
+
+  # As a result, sc_finalize() may generate an error and is not safe to
+  # to call it at this point.
+
+  # sc_finalize()
   return nothing
 end
 

--- a/src/Environment.jl
+++ b/src/Environment.jl
@@ -1,6 +1,10 @@
 
 const _NREFS = Ref(0)
 
+"""
+See P4est_wrapper.jl/src/bindings/sc_common.jl for possible/valid
+argument values for the p4est_verbosity_level parameter
+"""
 function Init(parts::MPIData;p4est_verbosity_level=P4est_wrapper.SC_LP_DEFAULT)
   if !MPI.Initialized()
     @error "MPI not Initialized!"
@@ -15,9 +19,13 @@ end
 function Finalize()
   GC.gc() # Finalize all object out of scope at this point
   if _NREFS[] != 0
-    @warn "$(_NREFS[]) objects still not finalized before calling GridapP4est.Finalize()"
+    @warn "$(_NREFS[]) object(s) still not finalized before calling GridapP4est.Finalize()"
   end
   _NREFS[] = 0
+  # This function call is useful, as among others, it also double checks
+  # for memory leaks as a result of improper usage of p4est/sc. If there are leaks, 
+  # then it generates a fatal error.
+  sc_finalize()
   return nothing
 end
 

--- a/src/OctreeDistributedDiscreteModels.jl
+++ b/src/OctreeDistributedDiscreteModels.jl
@@ -7,22 +7,22 @@ mutable struct OctreeDistributedDiscreteModel{Dc,Dp,A,B,C,D,E} <: GridapDistribu
   ptr_pXest_connectivity      :: D
   ptr_pXest                   :: E
 
-  # The model for which this variable is true, is the one 
-  # ultimately responsible for deallocating the pXest_connectivity 
+  # The model for which this variable is true, is the one
+  # ultimately responsible for deallocating the pXest_connectivity
   # info
   owns_ptr_pXest_connectivity :: Bool
-  
-  # Might be optionally be used, e.g., to enforce that this 
+
+  # Might be optionally be used, e.g., to enforce that this
   # model is GCed after another existing model
   gc_ref                      :: Any
   function OctreeDistributedDiscreteModel(
-    Dc::Int, 
+    Dc::Int,
     Dp::Int,
     parts,
     dmodel::Union{GridapDistributed.AbstractDistributedDiscreteModel,Nothing},
     coarse_model,
     ptr_pXest_connectivity,
-    ptr_pXest, 
+    ptr_pXest,
     owns_ptr_pXest_connectivity::Bool,
     gc_ref)
 
@@ -30,7 +30,7 @@ mutable struct OctreeDistributedDiscreteModel{Dc,Dp,A,B,C,D,E} <: GridapDistribu
       Gridap.Helpers.@check Dc == Gridap.Geometry.num_cell_dims(dmodel)
       Gridap.Helpers.@check Dc == Gridap.Geometry.num_point_dims(dmodel)
     end
-  
+
     A = typeof(parts)
     B = typeof(dmodel)
     C = typeof(coarse_model)
@@ -40,7 +40,7 @@ mutable struct OctreeDistributedDiscreteModel{Dc,Dp,A,B,C,D,E} <: GridapDistribu
                                  dmodel,
                                  coarse_model,
                                  ptr_pXest_connectivity,
-                                 ptr_pXest, 
+                                 ptr_pXest,
                                  owns_ptr_pXest_connectivity,
                                  gc_ref)
     Init(model)
@@ -101,7 +101,7 @@ function OctreeDistributedDiscreteModel(parts::MPIData{<:Integer},
                                           true,
                                           nothing)
   else
-    ## HUGE WARNING: Shouldn't we provide here the complementary of parts 
+    ## HUGE WARNING: Shouldn't we provide here the complementary of parts
     ##               instead of parts? Otherwise, when calling _free!(...)
     ##               we cannot trust on parts.
     return VoidOctreeDistributedDiscreteModel(coarse_model,parts)
@@ -184,18 +184,16 @@ function octree_distributed_discrete_model_free!(model::OctreeDistributedDiscret
 end
 
 function Init(a::OctreeDistributedDiscreteModel)
-  _NREFS[] += 1
   finalizer(Finalize,a)
 end
 
 function Finalize(a::OctreeDistributedDiscreteModel)
   octree_distributed_discrete_model_free!(a)
-  _NREFS[] -= 1
   return nothing
 end
 
 ###################################################################
-# Private methods 
+# Private methods
 
 function pXest_copy(::Type{Val{Dc}}, ptr_pXest) where Dc
   if (Dc==2)
@@ -295,7 +293,7 @@ function _compute_fine_to_coarse_model_glue(
         fine_to_coarse_faces_dim,
           fcell_to_child_id =
           _process_owned_cells_fine_to_coarse_model_glue(cmodel_local,fmodel,cpartition,fpartition)
-      
+
       lids_snd    = fgids.exchanger.lids_snd.part
       lids_rcv    = fgids.exchanger.lids_rcv.part
       cgids_data  = cpartition.lid_to_gid[fine_to_coarse_faces_map[Dc+1][lids_snd.data]]
@@ -468,7 +466,7 @@ function Gridap.Adaptivity.refine(model::OctreeDistributedDiscreteModel{Dc,Dp}, 
                                      model.coarse_model,
                                      model.ptr_pXest_connectivity,
                                      ptr_new_pXest,
-                                     false, 
+                                     false,
                                      model)
       return ref_model, dglue
    else
@@ -528,10 +526,10 @@ end
 function _p4est_to_new_comm(ptr_pXest, ptr_pXest_conn, old_comm, new_comm)
   A=is_included(old_comm,new_comm) # old \subset new (smaller to larger nparts)
   B=is_included(new_comm,old_comm) # old \supset new (larger to smaller nparts)
-  @assert xor(A,B) 
+  @assert xor(A,B)
   if (A)
     _p4est_to_new_comm_old_subset_new(ptr_pXest, ptr_pXest_conn, old_comm, new_comm)
-  else 
+  else
     _p4est_to_new_comm_old_supset_new(ptr_pXest, ptr_pXest_conn, old_comm, new_comm)
   end
 end
@@ -574,8 +572,8 @@ function _p4est_to_new_comm_old_subset_new(ptr_pXest, ptr_pXest_conn, old_comm, 
                                        C_NULL)
   else
     return nothing
-  end                                     
-end 
+  end
+end
 
 function _p4est_to_new_comm_old_supset_new(ptr_pXest, ptr_pXest_conn, old_comm, new_comm)
   @assert GridapP4est.i_am_in(old_comm)
@@ -593,7 +591,7 @@ function _p4est_to_new_comm_old_supset_new(ptr_pXest, ptr_pXest_conn, old_comm, 
     old_global_first_quadrant = unsafe_wrap(Array,
                                             pXest.global_first_quadrant,
                                             old_comm_num_parts+1)
-    
+
     new_global_first_quadrant = unsafe_wrap(Array,
                                             pXest.global_first_quadrant,
                                             new_comm_num_parts+1)
@@ -611,10 +609,10 @@ function _p4est_to_new_comm_old_supset_new(ptr_pXest, ptr_pXest_conn, old_comm, 
                                       quadrants,
                                       C_NULL,
                                       C_NULL)
-  else 
-    return nothing 
-  end                                  
-end 
+  else
+    return nothing
+  end
+end
 
 
 function _p4est_tree_array_index(::Type{Val{Dc}},trees,itree) where Dc
@@ -723,27 +721,27 @@ function is_included(commA::MPI.Comm,commB::MPI.Comm)
   num_partsB=num_parts(commB)
   if (num_partsA==num_partsB)
     return false
-  end 
+  end
   if (i_am_in(commA) && i_am_in(commB))
     result=num_partsA < num_partsB
     if (result)
       result=MPI.Allreduce(Int8(result),MPI.LOR,commB)
     else
       result=MPI.Allreduce(Int8(result),MPI.LOR,commA)
-    end 
-  else 
+    end
+  else
     result=false
     if (i_am_in(commB))
       result=MPI.Allreduce(Int8(result),MPI.LOR,commB)
-    else 
+    else
       result=MPI.Allreduce(Int8(result),MPI.LOR,commA)
-    end 
+    end
   end
-  Bool(result) 
+  Bool(result)
 end
 
 # Assumptions. Either:
-# A) model.parts MPI tasks are included in parts_redistributed_model MPI tasks; or 
+# A) model.parts MPI tasks are included in parts_redistributed_model MPI tasks; or
 # B) model.parts MPI tasks include parts_redistributed_model MPI tasks
 function GridapDistributed.redistribute(model::OctreeDistributedDiscreteModel{Dc,Dp}, parts_redistributed_model=model.parts) where {Dc,Dp}
   parts = (parts_redistributed_model === model.parts) ? model.parts : parts_redistributed_model
@@ -758,7 +756,7 @@ function GridapDistributed.redistribute(model::OctreeDistributedDiscreteModel{Dc
       _redistribute_parts_subseteq_parts_redistributed(model,parts_redistributed_model)
     else
       _redistribute_parts_supset_parts_redistributed(model, parts_redistributed_model)
-    end 
+    end
   else
     VoidOctreeDistributedDiscreteModel(model,model.parts), nothing
   end
@@ -781,7 +779,7 @@ function _redistribute_parts_subseteq_parts_redistributed(model::OctreeDistribut
   parts_snd, lids_snd, old2new = _p4est_compute_migration_control_data(Val{Dc},ptr_pXest_old,ptr_pXest_new)
   parts_rcv, lids_rcv, new2old = _p4est_compute_migration_control_data(Val{Dc},ptr_pXest_new,ptr_pXest_old)
 
-  lids_rcv, parts_rcv, lids_snd, parts_snd, old2new, new2old = 
+  lids_rcv, parts_rcv, lids_snd, parts_snd, old2new, new2old =
        _to_pdata(parts, lids_rcv, parts_rcv, lids_snd, parts_snd, old2new, new2old)
 
   glue = GridapDistributed.RedistributeGlue(parts_rcv,parts_snd,lids_rcv,lids_snd,old2new,new2old)
@@ -814,20 +812,20 @@ function _redistribute_parts_subseteq_parts_redistributed(model::OctreeDistribut
 end
 
 function _redistribute_parts_supset_parts_redistributed(model::OctreeDistributedDiscreteModel{Dc,Dp}, parts_redistributed_model) where {Dc,Dp}
-  @assert model.parts !== parts_redistributed_model 
-  
+  @assert model.parts !== parts_redistributed_model
+
   subset_comm = parts_redistributed_model.comm
   supset_comm = model.parts.comm
   N=num_cells(model)
   if (i_am_in(subset_comm))
-    # This piece of code replicates the logic behind the 
+    # This piece of code replicates the logic behind the
     # "p4est_partition_cut_gloidx" function in the p4est library
     psub=parts_redistributed_model.part
     Psub=num_parts(subset_comm)
     first_global_quadrant=Int64((Float64(N)*Float64(psub-1))/(Float64(Psub)))
     @assert first_global_quadrant>=0 && first_global_quadrant<N
     # print("$(N) $(Psub) $(psub): $(first_global_quadrant)","\n")
-  else 
+  else
     first_global_quadrant=N
   end
 
@@ -849,20 +847,20 @@ function _redistribute_parts_supset_parts_redistributed(model::OctreeDistributed
 
   # ptr_pXest_old is distributed over supset_comm
   # once created, ptr_pXest_new is distributed over subset_comm
-  ptr_pXest_new = _p4est_to_new_comm(ptr_pXest_old, 
+  ptr_pXest_new = _p4est_to_new_comm(ptr_pXest_old,
                                      model.ptr_pXest_connectivity,
                                      supset_comm,
                                      subset_comm)
 
   # Compute RedistributeGlue
-  parts_snd, lids_snd, old2new = 
+  parts_snd, lids_snd, old2new =
       _p4est_compute_migration_control_data(Val{Dc},model.ptr_pXest,ptr_pXest_old)
-  parts_rcv, lids_rcv, new2old = 
+  parts_rcv, lids_rcv, new2old =
       _p4est_compute_migration_control_data(Val{Dc},ptr_pXest_old,model.ptr_pXest)
 
-  pXest_destroy(Val{Dc},ptr_pXest_old)   
+  pXest_destroy(Val{Dc},ptr_pXest_old)
 
-  lids_rcv, parts_rcv, lids_snd, parts_snd, old2new, new2old = 
+  lids_rcv, parts_rcv, lids_snd, parts_snd, old2new, new2old =
        _to_pdata(model.parts, lids_rcv, parts_rcv, lids_snd, parts_snd, old2new, new2old)
 
   glue = GridapDistributed.RedistributeGlue(parts_rcv,parts_snd,lids_rcv,lids_snd,old2new,new2old)
@@ -894,7 +892,7 @@ function _redistribute_parts_supset_parts_redistributed(model::OctreeDistributed
                                                ptr_pXest_new,
                                                false,
                                                model)
-    return red_model, glue 
+    return red_model, glue
   else
     return VoidOctreeDistributedDiscreteModel(model,parts_redistributed_model), nothing
   end
@@ -911,4 +909,4 @@ function _to_pdata(parts, lids_rcv, parts_rcv, lids_snd, parts_snd, old2new, new
     old2new,new2old
   end
   lids_rcv, parts_rcv, lids_snd, parts_snd, old2new, new2old
-end 
+end

--- a/src/UniformlyRefinedForestOfOctreesDiscreteModels.jl
+++ b/src/UniformlyRefinedForestOfOctreesDiscreteModels.jl
@@ -919,17 +919,11 @@ end
 
 
 """
-  See P4est_wrapper.jl/src/bindings/sc_common.jl for possible/valid
-  argument values for the p4est_verbosity_level parameter
 """
 function UniformlyRefinedForestOfOctreesDiscreteModel(
     parts::MPIData{<:Integer},
     coarse_discrete_model::DiscreteModel{Dc,Dp},
-    num_uniform_refinements::Int;
-    p4est_verbosity_level=P4est_wrapper.SC_LP_DEFAULT) where {Dc,Dp}
-
-  sc_init(parts.comm, Cint(true), Cint(true), C_NULL, p4est_verbosity_level)
-  p4est_init(C_NULL, p4est_verbosity_level)
+    num_uniform_refinements::Int) where {Dc,Dp}
 
   comm = parts.comm
   ptr_pXest_connectivity,
@@ -954,7 +948,5 @@ function UniformlyRefinedForestOfOctreesDiscreteModel(
   pXest_ghost_destroy(Val{Dc},ptr_pXest_ghost)
   pXest_destroy(Val{Dc},ptr_pXest)
   pXest_connectivity_destroy(Val{Dc},ptr_pXest_connectivity)
-
-  sc_finalize()
   dmodel
 end

--- a/test/OctreeDistributedDiscreteModelsTests.jl
+++ b/test/OctreeDistributedDiscreteModelsTests.jl
@@ -9,11 +9,11 @@ module OctreeDistributedDiscreteModelsTests
   using GridapP4est
   using P4est_wrapper
 
-  import Gridap.Adaptivity: refine 
+  import Gridap.Adaptivity: refine
   import GridapDistributed: redistribute
 
   function run(parts,subdomains,num_parts_x_level)
-    GridapP4est.with(parts) do 
+    GridapP4est.with(parts) do
       if length(subdomains) == 2
         domain=(0,1,0,1)
       else
@@ -24,58 +24,53 @@ module OctreeDistributedDiscreteModelsTests
       # Generate model
       level_parts  = GridapP4est.generate_level_parts(parts,num_parts_x_level)
       coarse_model = CartesianDiscreteModel(domain,subdomains)
-      
       model        = OctreeDistributedDiscreteModel(level_parts[2],coarse_model,1)
-      
-      vmodel       = GridapP4est.VoidOctreeDistributedDiscreteModel(coarse_model,parts)
+      vmodel1      = GridapP4est.VoidOctreeDistributedDiscreteModel(model,parts)
+      vmodel2      = GridapP4est.VoidOctreeDistributedDiscreteModel(coarse_model,parts)
 
       # Refining and distributing
-      # fmodel , rglue  = refine(model,level_parts[1])
-      # dfmodel, dglue  = redistribute(fmodel)
+      fmodel , rglue  = refine(model,level_parts[1])
+      dfmodel, dglue  = redistribute(fmodel)
 
-      # # FESpaces tests
-      # sol(x) = x[1] + x[2]
-      # reffe = ReferenceFE(lagrangian,Float64,1)
-      # test  = TestFESpace(dfmodel, reffe; conformity=:H1)
-      # trial = TrialFESpace(sol,test)
-  
-      # # Refine 
-      # fmodel_tasks_L2, rglue  = refine(model)
-      
-      # # Redistribute L2 -> L1 
-      # fmodel_tasks_L1, dglueL2toL1  = redistribute(fmodel_tasks_L2,level_parts[1])
-      # if GridapP4est.i_am_in(level_parts[1])
-      #   @test fmodel_tasks_L1.parts === PartitionedArrays.get_part_ids(dglueL2toL1.parts_rcv)
-      # end
+      # FESpaces tests
+      sol(x) = x[1] + x[2]
+      reffe = ReferenceFE(lagrangian,Float64,1)
+      test  = TestFESpace(dfmodel, reffe; conformity=:H1)
+      trial = TrialFESpace(sol,test)
 
-      # # Redistribute L1 -> L2
-      # f_model_tasks_L2_back, dglueL1toL2 = redistribute(fmodel_tasks_L1,level_parts[2])
-      
-      # # Coarsening 
-      # model_back,glue = coarsen(f_model_tasks_L2_back)
+      # Refine
+      fmodel_tasks_L2, rglue  = refine(model)
 
-      # if (GridapP4est.i_am_in(level_parts[2]))
-      #   @test num_cells(model_back)==num_cells(model)
-      #   map_parts(model.dmodel.models,model_back.dmodel.models) do m1, m2 
-      #     Ωh1  = Triangulation(m1)
-      #     dΩh1 = Measure(Ωh1,2)
-      #     Ωh2  = Triangulation(m2)
-      #     dΩh2 = Measure(Ωh2,2)
-      #     sum(∫(1)dΩh1) ≈ sum(∫(1)dΩh2)
-      #   end 
-      # end
+      # Redistribute L2 -> L1
+      fmodel_tasks_L1, dglueL2toL1  = redistribute(fmodel_tasks_L2,level_parts[1])
+      if GridapP4est.i_am_in(level_parts[1])
+        @test fmodel_tasks_L1.parts === PartitionedArrays.get_part_ids(dglueL2toL1.parts_rcv)
+      end
 
-      # model  = OctreeDistributedDiscreteModel(level_parts[1],coarse_model,3)
-      # imodel = model
-      # for i=1:3
-      #   omodel,glue=coarsen(imodel)
-      #   if (imodel!==model)
-      #     octree_distributed_discrete_model_free!(imodel)
-      #   end   
-      #   imodel=omodel
-      # end
-      # @test num_cells(imodel)==prod(subdomains)
+      # Redistribute L1 -> L2
+      f_model_tasks_L2_back, dglueL1toL2 = redistribute(fmodel_tasks_L1,level_parts[2])
 
+      # Coarsening
+      model_back,glue = coarsen(f_model_tasks_L2_back)
+
+      if (GridapP4est.i_am_in(level_parts[2]))
+        @test num_cells(model_back)==num_cells(model)
+        map_parts(model.dmodel.models,model_back.dmodel.models) do m1, m2
+          Ωh1  = Triangulation(m1)
+          dΩh1 = Measure(Ωh1,2)
+          Ωh2  = Triangulation(m2)
+          dΩh2 = Measure(Ωh2,2)
+          sum(∫(1)dΩh1) ≈ sum(∫(1)dΩh2)
+        end
+      end
+
+      model  = OctreeDistributedDiscreteModel(level_parts[1],coarse_model,3)
+      imodel = model
+      for i=1:3
+        omodel,glue=coarsen(imodel)
+        imodel=omodel
+      end
+      @test num_cells(imodel)==prod(subdomains)
       nothing
     end
   end

--- a/test/OctreeDistributedDiscreteModelsTests.jl
+++ b/test/OctreeDistributedDiscreteModelsTests.jl
@@ -24,55 +24,59 @@ module OctreeDistributedDiscreteModelsTests
       # Generate model
       level_parts  = GridapP4est.generate_level_parts(parts,num_parts_x_level)
       coarse_model = CartesianDiscreteModel(domain,subdomains)
+      
       model        = OctreeDistributedDiscreteModel(level_parts[2],coarse_model,1)
-      vmodel       = GridapP4est.VoidOctreeDistributedDiscreteModel(model,parts)
+      
+      vmodel       = GridapP4est.VoidOctreeDistributedDiscreteModel(coarse_model,parts)
 
       # Refining and distributing
-      fmodel , rglue  = refine(model,level_parts[1])
-      dfmodel, dglue  = redistribute(fmodel)
+      # fmodel , rglue  = refine(model,level_parts[1])
+      # dfmodel, dglue  = redistribute(fmodel)
 
-      # FESpaces tests
-      sol(x) = x[1] + x[2]
-      reffe = ReferenceFE(lagrangian,Float64,1)
-      test  = TestFESpace(dfmodel, reffe; conformity=:H1)
-      trial = TrialFESpace(sol,test)
+      # # FESpaces tests
+      # sol(x) = x[1] + x[2]
+      # reffe = ReferenceFE(lagrangian,Float64,1)
+      # test  = TestFESpace(dfmodel, reffe; conformity=:H1)
+      # trial = TrialFESpace(sol,test)
   
-      # Refine 
-      fmodel_tasks_L2, rglue  = refine(model)
+      # # Refine 
+      # fmodel_tasks_L2, rglue  = refine(model)
       
-      # Redistribute L2 -> L1 
-      fmodel_tasks_L1, dglueL2toL1  = redistribute(fmodel_tasks_L2,level_parts[1])
-      if GridapP4est.i_am_in(level_parts[1])
-        @test fmodel_tasks_L1.parts === PartitionedArrays.get_part_ids(dglueL2toL1.parts_rcv)
-      end
+      # # Redistribute L2 -> L1 
+      # fmodel_tasks_L1, dglueL2toL1  = redistribute(fmodel_tasks_L2,level_parts[1])
+      # if GridapP4est.i_am_in(level_parts[1])
+      #   @test fmodel_tasks_L1.parts === PartitionedArrays.get_part_ids(dglueL2toL1.parts_rcv)
+      # end
 
-      # Redistribute L1 -> L2
-      f_model_tasks_L2_back, dglueL1toL2 = redistribute(fmodel_tasks_L1,level_parts[2])
+      # # Redistribute L1 -> L2
+      # f_model_tasks_L2_back, dglueL1toL2 = redistribute(fmodel_tasks_L1,level_parts[2])
       
-      # Coarsening 
-      model_back,glue = coarsen(f_model_tasks_L2_back)
+      # # Coarsening 
+      # model_back,glue = coarsen(f_model_tasks_L2_back)
 
-      if (GridapP4est.i_am_in(level_parts[2]))
-        @test num_cells(model_back)==num_cells(model)
-        map_parts(model.dmodel.models,model_back.dmodel.models) do m1, m2 
-          Ωh1  = Triangulation(m1)
-          dΩh1 = Measure(Ωh1,2)
-          Ωh2  = Triangulation(m2)
-          dΩh2 = Measure(Ωh2,2)
-          sum(∫(1)dΩh1) ≈ sum(∫(1)dΩh2)
-        end 
-      end
+      # if (GridapP4est.i_am_in(level_parts[2]))
+      #   @test num_cells(model_back)==num_cells(model)
+      #   map_parts(model.dmodel.models,model_back.dmodel.models) do m1, m2 
+      #     Ωh1  = Triangulation(m1)
+      #     dΩh1 = Measure(Ωh1,2)
+      #     Ωh2  = Triangulation(m2)
+      #     dΩh2 = Measure(Ωh2,2)
+      #     sum(∫(1)dΩh1) ≈ sum(∫(1)dΩh2)
+      #   end 
+      # end
 
-      model  = OctreeDistributedDiscreteModel(level_parts[1],coarse_model,3)
-      imodel = model
-      for i=1:3
-        omodel,glue=coarsen(imodel)
-        if (imodel!==model)
-          octree_distributed_discrete_model_free!(imodel)
-        end   
-        imodel=omodel
-      end
-      @test num_cells(imodel)==prod(subdomains)
+      # model  = OctreeDistributedDiscreteModel(level_parts[1],coarse_model,3)
+      # imodel = model
+      # for i=1:3
+      #   omodel,glue=coarsen(imodel)
+      #   if (imodel!==model)
+      #     octree_distributed_discrete_model_free!(imodel)
+      #   end   
+      #   imodel=omodel
+      # end
+      # @test num_cells(imodel)==prod(subdomains)
+
+      nothing
     end
   end
 

--- a/test/UniformlyRefinedForestOfOctreesDiscreteModelsTests.jl
+++ b/test/UniformlyRefinedForestOfOctreesDiscreteModelsTests.jl
@@ -27,63 +27,66 @@ module UniformlyRefinedForestOfOctreesDiscreteModelsTests
   end
 
   function run(parts,subdomains,num_uniform_refinements)
-    # Manufactured solution
-    u(x) = x[1] + x[2]
-    f(x) = -Δ(u)(x)
+    GridapP4est.with(parts;p4est_verbosity_level=P4est_wrapper.SC_LP_STATISTICS) do 
+        # Manufactured solution
+        u(x) = x[1] + x[2]
+        f(x) = -Δ(u)(x)
 
-    if length(subdomains)==2
-      domain=(0,1,0,1)
-    else
-      @assert length(subdomains)==3
-      domain=(0,1,0,1,0,1)
-    end
+        if length(subdomains)==2
+          domain=(0,1,0,1)
+        else
+          @assert length(subdomains)==3
+          domain=(0,1,0,1,0,1)
+        end
 
-    coarse_discrete_model=CartesianDiscreteModel(domain,subdomains)
-    model=UniformlyRefinedForestOfOctreesDiscreteModel(parts,
-                                                       coarse_discrete_model,
-                                                       num_uniform_refinements)
+        coarse_discrete_model=CartesianDiscreteModel(domain,subdomains)
+        model=UniformlyRefinedForestOfOctreesDiscreteModel(parts,
+                                                          coarse_discrete_model,
+                                                          num_uniform_refinements)
 
-    # FE Spaces
-    order=1
-    reffe = ReferenceFE(lagrangian,Float64,order)
-    V = TestFESpace(model,reffe,dirichlet_tags="boundary")
-    U = TrialFESpace(u,V)
+        # FE Spaces
+        order=1
+        reffe = ReferenceFE(lagrangian,Float64,order)
+        V = TestFESpace(model,reffe,dirichlet_tags="boundary")
+        U = TrialFESpace(u,V)
 
-    trian=Triangulation(model)
-    dΩ=Measure(trian,2*(order+1))
+        trian=Triangulation(model)
+        dΩ=Measure(trian,2*(order+1))
 
-    function a(u,v)
-      ∫(∇(v)⋅∇(u))dΩ
-    end
-    function l(v)
-      ∫(v*f)dΩ
-    end
-    dv = get_fe_basis(V)
-    du = get_trial_fe_basis(U)
-    assem = SparseMatrixAssembler(U,V)
+        function a(u,v)
+          ∫(∇(v)⋅∇(u))dΩ
+        end
+        function l(v)
+          ∫(v*f)dΩ
+        end
+        dv = get_fe_basis(V)
+        du = get_trial_fe_basis(U)
+        assem = SparseMatrixAssembler(U,V)
 
-    dof_values = PVector(0.0,V.gids)
-    uh = FEFunction(U,dof_values)
-    data = collect_cell_matrix_and_vector(U,V,a(du,dv),l(dv),uh)
-    A,b = assemble_matrix_and_vector(assem,data)
+        dof_values = PVector(0.0,V.gids)
+        uh = FEFunction(U,dof_values)
+        data = collect_cell_matrix_and_vector(U,V,a(du,dv),l(dv),uh)
+        A,b = assemble_matrix_and_vector(assem,data)
 
-    x = A\b
-    r = A*x -b
-    uh = FEFunction(U,x)
+        x = A\b
+        r = A*x -b
+        uh = FEFunction(U,x)
 
-    # Error norms and print solution
-    trian=Triangulation(model)
-    dΩ=Measure(trian,2*order)
-    e = u-uh
-    e_l2 = sum(∫(e*e)dΩ)
-    tol = 1.0e-9
-    @test e_l2 < tol
-    map_parts(parts) do part
-     if (part==1)
-       println("$(e_l2) < $(tol)\n")
-     end
-    end
+        # Error norms and print solution
+        trian=Triangulation(model)
+        dΩ=Measure(trian,2*order)
+        e = u-uh
+        e_l2 = sum(∫(e*e)dΩ)
+        tol = 1.0e-9
+        @test e_l2 < tol
+        map_parts(parts) do part
+        if (part==1)
+          println("$(e_l2) < $(tol)\n")
+        end
+      end
+    end 
   end
+
   if !MPI.Initialized()
     MPI.Init()
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,9 +5,6 @@ using MPI
 using ArgParse
 using Test
 
-#@time @testset "RichardsonSmoothers" begin include("GMG/seq/RichardsonSmoothersTests.jl") end
-#@time @testset "PatchLinearSolverTests" begin include("GMG/seq/PatchLinearSolverTests.jl") end
-
 function parse_commandline()
     s = ArgParseSettings()
     @add_arg_table! s begin
@@ -57,6 +54,5 @@ function run_tests(testdir)
 end
 
 run_tests(@__DIR__)
-#run_tests(joinpath(@__DIR__, "GMG/mpi"))
 
 end # module


### PR DESCRIPTION
WORK IN PROGRESS ... DO NOT MERGE !!!

@JordiManyer

I have been working on the issues which, in my view, are still pending from PR #27.  I have done the changes in a separate branch/PR instead of pushing directly. Why? Among others, I am not still 100% sure if we will be able to let all this work as we intend (there are still issues to be solved in this PR). 

Let me share with you what I've learned/done while reviewing PR #27 and developing/debugging code myself:

* The SC library, on which p4est relies to do memory allocation, has its own internal memory tracker. If there is still memory to be freed (allocated within p4est using mechanisms of the SC library) when calling `sc_finalize()`, this function generates an exception with error messages looking as:

```
[1,0]<stdout>:[libsc 0] Abort: Memory balance (p4est)
[1,0]<stdout>:[libsc 0] Abort: src/sc.c:704
```

* Due to this, I guess that the main reason you were having issues with `sc_finalize()` in PR #27  has to do with improper automatic deallocation of p4est objects. 

* A mejor source of concern is `p4est_connectivity_t`. We must deallocate it properly if we want to avoid `sc_finalize()` generating the execption. At present, if am not wrong, PR #27 does not actually handle this situation properly. I have implemented a mechanism based on two extra member variables of `OctreeDistributedModel` in order to handle the automatic deallocation of `p4est_connectivity_t`. 

* However, I am stuck because, at present, (a very narrowed down with just a couple of calls to octree models constructors) `OctreeDistributedModelTests.jl` fails due to "memory balance" and i am not able to see why (see https://github.com/gridap/GridapP4est.jl/actions/runs/3928266265/jobs/6715692901#step:10:32 for more details).  When I execute the tests with only either of these lines the error disappears!!!

* As a general comment, it concerns me that using a closure for the `f()` function passed to `with` may prevent this mechanism to work in general. I think this is not the case for the particular case of `OctreeDistributedModelTests.jl`, but I can think of scenarios where this may impact us.

* Another source of concern: https://github.com/gridap/GridapP4est.jl/commit/30a1111bb8ef850dea8749895c0f83da15ae3035#diff-cd498b7d7a8e9e6a025d0292efa3c176454e98fee8b550bae973aea59bffc3eeR104