### PR TITLE
Fix in _add_constraints()

### DIFF
--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -775,7 +775,7 @@ function _add_constraints(model::GridapDistributed.DistributedDiscreteModel{Dc},
                           spaces_wo_constraints;
                           conformity=nothing,
                           kwargs...) where {Dc}
-    if (conformity!=nothing && conformity!=:L2)
+    if (conformity==nothing || conformity!=:L2)
       ref_constraints = _build_constraint_coefficients_matrix_in_ref_space(Dc, reffe)
 
       face_subface_ldof_to_cell_ldof = Vector{Vector{Vector{Vector{Int32}}}}(undef, Dc-1)


### PR DESCRIPTION
Fix in order to have an _add_constraints() function which is consistent
with the logic of the local Gridap FESpace constructor

Before the fix, whenever we were not passing the conformity kw-arg, we were building a H1-conforming space only for the conforming mesh interfaces and we were not gluing at all the non-conforming ones