### PR TITLE
Ghost skeletons on empty triangulations

### DIFF
--- a/src/Geometry.jl
+++ b/src/Geometry.jl
@@ -386,6 +386,7 @@ end
 
 function Gridap.Arrays.evaluate!(cache,f::SubfaceRefCoordsMap,gface::Integer)
   poly_vertices,cell_coordinates,cache_cell_coordinates=cache
+  isempty(f.face_is_owner) && return empty(poly_vertices)
   if (f.face_is_owner[gface])
     subface=f.face_to_subface[gface]
     getindex!(cache_cell_coordinates,cell_coordinates,subface)


### PR DESCRIPTION
Hello @amartinhuertas,

I needed to handle empty faces when evaluating SubfaceRefCoordsMap in order to generate ghost skeletons on empty triangulations.

There might be a cleaner way to do this, but I'd say it requires structural changes (and, in my case, to have a more complete understanding of the code). If I can help with the refactor, lmk.

Thanks a lot!