### PR TITLE
Bug-fix p6est vertically and horizontally reset call backs + bug-fix in hanging faces with off-process owner

### DIFF
--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -422,7 +422,8 @@ end
 function _generate_hanging_faces_owner_face_dofs(num_hanging_faces,
     face_dofs,
     hanging_faces_glue,
-    cell_dof_ids)
+    cell_dof_ids,
+    fake_master_dof_id)
 
     cache = array_cache(cell_dof_ids)
     ptrs = Vector{Int}(undef, num_hanging_faces + 1)
@@ -449,8 +450,12 @@ function _generate_hanging_faces_owner_face_dofs(num_hanging_faces,
             data_owner_face_dofs[s+j-1] = current_cell_dof_ids[ldof]
           end
         else 
+          # This scenario corresponds to the case of a hanging face in the global mesh such that its
+          # owner face is not in the local portion of the processor. We need such a dof to be constrained
+          # but the question is by which dof. The fake_master_dof_id provides the dof that satisfies all 
+          # the required preconditions of FESpaceWithLinearConstraints
           s = ptrs[fid_hanging]
-          data_owner_face_dofs[s] = 1
+          data_owner_face_dofs[s] = fake_master_dof_id
         end
     end
     Gridap.Arrays.Table(data_owner_face_dofs, ptrs)
@@ -690,6 +695,16 @@ function get_face_dofs_permutations(
     end
 end 
 
+function _determine_fake_master_dof_id(V::SingleFieldFESpace)
+    if (num_dirichlet_dofs(V) > 0)
+        return -1
+    else
+        @assert num_free_dofs(V) > 0
+        return 1
+    end
+
+end 
+
 function generate_constraints(dmodel::GridapDistributed.DistributedDiscreteModel{Dc},
     spaces_wo_constraints,
     cell_reffe,
@@ -748,24 +763,29 @@ function generate_constraints(dmodel::GridapDistributed.DistributedDiscreteModel
         face_own_dofs = Gridap.ReferenceFEs.get_face_own_dofs(cell_reffe)
         face_dofs = Gridap.ReferenceFEs.get_face_dofs(cell_reffe)
 
+        fake_master_dof_id = _determine_fake_master_dof_id(V)
+
         hanging_faces_owner_face_dofs = Vector{Vector{Vector{Int}}}(undef, Dc)
 
         hanging_faces_owner_face_dofs[1] = _generate_hanging_faces_owner_face_dofs(num_hanging_faces[1],
             face_dofs,
             hanging_faces_glue[1],
-            cell_dof_ids)
+            cell_dof_ids,
+            fake_master_dof_id)
 
         if (Dc == 3)
             hanging_faces_owner_face_dofs[2] = _generate_hanging_faces_owner_face_dofs(num_hanging_faces[2],
                 face_dofs,
                 hanging_faces_glue[2],
-                cell_dof_ids)
+                cell_dof_ids,
+                fake_master_dof_id)
         end
 
         hanging_faces_owner_face_dofs[Dc] = _generate_hanging_faces_owner_face_dofs(num_hanging_faces[Dc],
             face_dofs,
             hanging_faces_glue[Dc],
-            cell_dof_ids)
+            cell_dof_ids,
+            fake_master_dof_id)
 
         sDOF_to_dof = Int[]
         sDOF_to_dofs = Vector{Int}[]
@@ -979,10 +999,17 @@ function _add_constraints(model,
                                                              kwargs...)
 
     nldofs = map(num_free_dofs,spaces_w_constraints)
+    map(nldofs) do nldof
+         @debug "[$(MPI.Comm_rank(MPI.COMM_WORLD))]: nldof=$(nldof)"
+    end
+    map(partition(cell_gids)) do indices 
+         @debug "[$(part_id(indices))]: l2g_cell_gids=$(local_to_global(indices))"
+         @debug "[$(part_id(indices))]: l2o_cell_owner=$(local_to_owner(indices))"
+    end
     gids = GridapDistributed.generate_gids(cell_gids,local_cell_dof_ids,nldofs)
     map(partition(gids)) do indices 
-         @debug "[$(part_id(indices))]: l2g_cell_gids=$(local_to_global(indices))"
-         @debug "[$(part_id(indices))]: l2o_owner=$(local_to_owner(indices))"
+         @debug "[$(part_id(indices))]: l2g_dof_gids=$(local_to_global(indices))"
+         @debug "[$(part_id(indices))]: l2o_dof_owner=$(local_to_owner(indices))"
     end
     vector_type = GridapDistributed._find_vector_type(spaces_w_constraints,gids; split_own_and_ghost=split_own_and_ghost)
     space = GridapDistributed.DistributedSingleFieldFESpace(spaces_w_constraints,gids,trian,vector_type)

--- a/src/PXestTypeMethods.jl
+++ b/src/PXestTypeMethods.jl
@@ -432,57 +432,18 @@ function p2est_quadrant_is_ancestor(a,b)
 end
 
 function p6est_vertically_adapt_reset_callbacks()
-  current_quadrant_index_among_trees  = Cint(-1)
-  current_quadrant_index_within_tree  = Cint(0)
-  current_layer_within_column         = Cint(0)
-  current_layer                       = Cint(0)
-  previous_tree                       = Cint(-1)
-  
-
+  current_layer = Cint(0)
   function init_fn_callback(forest_ptr::Ptr{p6est_t},
     which_tree::p4est_topidx_t,
     column_ptr::Ptr{p4est_quadrant_t},
     layer_ptr::Ptr{p2est_quadrant_t})
-
     forest = forest_ptr[]
-    columns = forest.columns[]
-    tree = p4est_tree_array_index(columns.trees, which_tree)[]
-    quadrant = column_ptr[]
     layer = layer_ptr[]
-  
-    if (current_quadrant_index_among_trees==-1 || which_tree != previous_tree)
-      previous_tree = which_tree
-      current_quadrant_index_among_trees = current_quadrant_index_among_trees+1
-      current_quadrant_index_within_tree = (current_quadrant_index_within_tree + 1) % (tree.quadrants.elem_count)
-      q = p4est_quadrant_array_index(tree.quadrants, current_quadrant_index_within_tree)
-      #@assert p4est_quadrant_compare(q,column_ptr) == 0
-      current_layer_within_column = 0
-    end
-  
-    q = p4est_quadrant_array_index(tree.quadrants, current_quadrant_index_within_tree)
-    #@assert p4est_quadrant_compare(q,column_ptr) == 0
-
-
-    user_data  = unsafe_wrap(Array, Ptr{Cint}(forest.user_pointer), current_layer+1)[current_layer+1]
-
-  
-    f,l=P6EST_COLUMN_GET_RANGE(column_ptr[])
-    q2_ptr=p2est_quadrant_array_index(forest.layers[], f+current_layer_within_column)
-    @assert p2est_quadrant_is_equal(q2_ptr,layer_ptr)
-
-    unsafe_store!(Ptr{Cint}(q2_ptr[].p.user_data), user_data, 1)
-  
-  
-    current_layer_within_column=current_layer_within_column+1
+    user_data  = unsafe_wrap(Array, 
+                             Ptr{Cint}(forest.user_pointer), 
+                             current_layer+1)[current_layer+1]
+    unsafe_store!(Ptr{Cint}(layer.p.user_data), user_data, 1)
     current_layer=current_layer+1                          
-        
-    if ((which_tree+1)==columns.connectivity[].num_trees && 
-        current_quadrant_index_within_tree==tree.quadrants.elem_count && 
-        current_layer_within_column==l-f)
-      current_quadrant_index_among_trees = Cint(-1)
-      current_layer=Cint(0)
-    end 
-  
     return nothing
   end
 
@@ -493,33 +454,19 @@ end
 
 
 function p6est_horizontally_adapt_reset_callbacks()
-  current_quadrant_index_among_trees  = Cint(-1)
-  current_quadrant_index_within_tree  = Cint(0)
-  current_layer_within_column         = Cint(0)
-  current_layer                       = Cint(0)
-  previous_tree                       = Cint(-1)
-
+  previous_f = Cint(-1)
+  current_quadrant_index_among_trees = Cint(0)
   function init_fn_callback(forest_ptr::Ptr{p6est_t},
     which_tree::p4est_topidx_t,
     column_ptr::Ptr{p4est_quadrant_t},
     layer_ptr::Ptr{p2est_quadrant_t})
 
     forest = forest_ptr[]
-    columns = forest.columns[]
-    tree = p4est_tree_array_index(columns.trees, which_tree)[]
-    quadrant = column_ptr[]
-    layer = layer_ptr[]
   
-    if (current_quadrant_index_among_trees==-1 || which_tree != previous_tree)
-      previous_tree = which_tree
-      current_quadrant_index_among_trees = current_quadrant_index_among_trees+1
-      current_quadrant_index_within_tree = (current_quadrant_index_within_tree + 1) % (tree.quadrants.elem_count)
-      q = p4est_quadrant_array_index(tree.quadrants, current_quadrant_index_within_tree)
-      current_layer_within_column = 0
-    end
     
     f,l=P6EST_COLUMN_GET_RANGE(column_ptr[])
-    if (current_layer_within_column==0)
+    if (f!=previous_f)
+       previous_f=f   
        user_data = 
           unsafe_wrap(Array, Ptr{Cint}(forest.user_pointer), 
              current_quadrant_index_among_trees+1)[current_quadrant_index_among_trees+1]
@@ -527,20 +474,9 @@ function p6est_horizontally_adapt_reset_callbacks()
        # to decide whether we refine the column or not   
        q2_ptr=p2est_quadrant_array_index(forest.layers[], f)
        @assert p2est_quadrant_is_equal(q2_ptr,layer_ptr)
-
        unsafe_store!(Ptr{Cint}(q2_ptr[].p.user_data), user_data, 1)
+       current_quadrant_index_among_trees = current_quadrant_index_among_trees+1
     end
-
-    current_layer_within_column=current_layer_within_column+1
-    current_layer=current_layer+1                          
-        
-    if ((which_tree+1)==columns.connectivity[].num_trees && 
-        current_quadrant_index_within_tree==tree.quadrants.elem_count && 
-        current_layer_within_column==l-f)
-      current_quadrant_index_among_trees = Cint(-1)
-      current_layer=Cint(0)
-      current_quadrant_index_within_tree = Cint(0)
-    end 
     return nothing
   end
   @cfunction($init_fn_callback, Cvoid, 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,7 +51,7 @@ function run_tests(testdir)
           np = [1,2,4]
           extra_args = ""
         elseif f in ["PoissonAnisotropicOctreeModelsTests.jl"] 
-          np = [1,4]
+          np = [1,2,4]
           extra_args = ""
         elseif f in ["PeriodicModels.jl"]
           np = [1]


### PR DESCRIPTION
+ src/PXestTypeMethods.jl — major simplification/bug-fix of p6est callbacks

* p6est_vertically_adapt_reset_callbacks: removed complex per-tree/column bookkeeping state; simplified init_fn_callback to directly read user_data from forest.user_pointer using a flat current_layer counter, and write it directly to layer.p.user_data (no more q2_ptr indirection or @assert)
* p6est_horizontally_adapt_reset_callbacks: replaced per-tree/layer index tracking with a simpler previous_f/current_quadrant_index_among_trees approach, detecting new columns via f != previous_f instead of current_layer_within_column == 0

+ src/FESpaces.jl — fix for hanging faces whose owner is off-processor

* Added _determine_fake_master_dof_id(V): returns -1 if there are Dirichlet dofs, otherwise 1, to provide a valid placeholder master dof for FESpaceWithLinearConstraints
* _generate_hanging_faces_owner_face_dofs: added fake_master_dof_id parameter; uses it instead of the hardcoded 1 when the owner face is not in the local partition
* Added debug log lines for nldof, cell gids, and dof gids in _add_constraints; fixed debug label typos (l2g_cell_gids → l2g_dof_gids, l2o_owner → l2o_dof_owner)

+ test/runtests.jl
* PoissonAnisotropicOctreeModelsTests.jl: added np=2 to the test process counts (was [1,4], now [1,2,4])