### PR TITLE
get_face_dofs_permutations for P space reffes

### DIFF
--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -660,6 +660,10 @@ function get_face_dofs_permutations(reffe::ReferenceFE,d::Integer)
     get_face_dofs_permutations(reffe)[range]
 end
 
+function get_face_dofs_permutations(reffe::GenericLagrangianRefFE{L2Conformity})
+    get_face_own_dofs_permutations(reffe,L2Conformity())
+end
+
 function get_face_dofs_permutations(
          reffe::Gridap.ReferenceFEs.GenericRefFE{<:Gridap.ReferenceFEs.RaviartThomas, Dc},Df::Integer) where Dc
     first_face = get_offset(get_polytope(reffe),Df)


### PR DESCRIPTION
Hello, @amartinhuertas,

I implemented `get_face_dofs_permutations` for the case that I set the FE space with a reffe like this

reffeᵖ = ReferenceFE(lagrangian,Float64,order-1,space=:P)`

i.e., whose local polynomial space is `:P`.

Lmk if you have any questions or suggestions for improvement. Otherwise, thanks a lot for accepting the PR.

Cheers,
Eric